### PR TITLE
Fixing a typo in the capstone evaluation link at badge criteria

### DIFF
--- a/projects/capstone5.md
+++ b/projects/capstone5.md
@@ -11,6 +11,6 @@ Unit test coverage in front-end and back-end should be at least 50% in each lang
 
 ## Evaluation:
 
-Ask your mentor if you are ready for project evaluation. Then, click [here](https://wevdev.codex.academy/capstone5) to request an evaluation.
+Ask your mentor if you are ready for project evaluation. Then, click [here](https://webdev.codex.academy/capstone5) to request an evaluation.
 
 [.](level-5)

--- a/projects/capstone6.md
+++ b/projects/capstone6.md
@@ -11,6 +11,6 @@ Unit test coverage in front-end and back-end should be at least 60% in each lang
 
 ## Evaluation:
 
-Ask your mentor if you are ready for project evaluation. Then, click [here](https://wevdev.codex.academy/capstone6) to request an evaluation.
+Ask your mentor if you are ready for project evaluation. Then, click [here](https://webdev.codex.academy/capstone6) to request an evaluation.
 
 [.](level-6)

--- a/projects/capstone7.md
+++ b/projects/capstone7.md
@@ -11,6 +11,6 @@ Unit test coverage in front-end and back-end should be at least 80% in each lang
 
 ## Evaluation:
 
-Ask your mentor if you are ready for project evaluation. Then, click [here](https://wevdev.codex.academy/capstone7) to request an evaluation.
+Ask your mentor if you are ready for project evaluation. Then, click [here](https://webdev.codex.academy/capstone7) to request an evaluation.
 
 [.](level-7)

--- a/projects/capstone8.md
+++ b/projects/capstone8.md
@@ -10,6 +10,6 @@ Unit test coverage in front-end and back-end should be at least 80% in each lang
 
 ## Evaluation:
 
-Ask your mentor if you are ready for project evaluation. Then, click [here](https://wevdev.codex.academy/capstone8) to request an evaluation.
+Ask your mentor if you are ready for project evaluation. Then, click [here](https://webdev.codex.academy/capstone8) to request an evaluation.
 
 [.](level-8)

--- a/projects/capstone9.md
+++ b/projects/capstone9.md
@@ -10,6 +10,6 @@ Unit test coverage in front-end and back-end should be at least 80% in each lang
 
 ## Evaluation:
 
-Ask your mentor if you are ready for project evaluation. Then, click [here](https://wevdev.codex.academy/capstone9) to request an evaluation.
+Ask your mentor if you are ready for project evaluation. Then, click [here](https://webdev.codex.academy/capstone9) to request an evaluation.
 
 [.](level-9)


### PR DESCRIPTION
This fixes issue #45 